### PR TITLE
Fix time performance, initialize BridgeDb datasources in main method

### DIFF
--- a/src/org/gk/gpml/CLIConverter.java
+++ b/src/org/gk/gpml/CLIConverter.java
@@ -15,6 +15,7 @@ import java.util.logging.FileHandler;
 import java.util.logging.Logger;
 import java.util.logging.SimpleFormatter;
 
+import org.bridgedb.bio.DataSourceTxt;
 import org.gk.model.GKInstance;
 import org.gk.model.ReactomeJavaConstants;
 import org.gk.persistence.MySQLAdaptor;
@@ -46,7 +47,11 @@ public class CLIConverter {
 		String version = args[7];
 		
 		dir.mkdirs();
-
+		
+		// Initialize BridgeDb datasources file
+		// Only have to do it once
+		DataSourceTxt.init();
+		
 		CLIConverter converter = new CLIConverter(adaptor);
 		/*
 		 * Boolean true to save ATXML files
@@ -77,15 +82,15 @@ public class CLIConverter {
 			if (species.equalsIgnoreCase("Human")) {
 				speciescode = 48887L;
 			} else if (species.equalsIgnoreCase("Rice")) {
-					speciescode = 186860;
-				} else if (species.equalsIgnoreCase("Maize")) {
-						speciescode = 5402224;
-					} else if (species.equalsIgnoreCase("Arabidopsis")) {
-							speciescode = 5398000;
-						}
-		dumpPathwayDiagrams(dir, speciescode, b, version);
+				speciescode = 186860;
+			} else if (species.equalsIgnoreCase("Maize")) {
+				speciescode = 5402224;
+			} else if (species.equalsIgnoreCase("Arabidopsis")) {
+				speciescode = 5398000;
+			}
+			dumpPathwayDiagrams(dir, speciescode, b, version);
 		}
-		}
+	}
 
 	private static void printUsage() throws Exception {
 		System.out

--- a/src/org/gk/gpml/ReactometoGPML2013.java
+++ b/src/org/gk/gpml/ReactometoGPML2013.java
@@ -270,7 +270,7 @@ public class ReactometoGPML2013 extends AbstractConverterFromReactome {
 			referenceEntity = (GKInstance) instance
 					.getAttributeValue(ReactomeJavaConstants.referenceEntity);
 		}
-		DataSourceTxt.init();
+
 		if (referenceEntity == null) {
 			/*
 			 * Use Reactome as default if no reference entity can be found


### PR DESCRIPTION
Fixed time performance of reactome pathways conversion.
Remove BridgeDb initialization in one loop and put it in the main method